### PR TITLE
Pull committee names, ids from bill actions; simplify detection of referral action types

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -499,6 +499,9 @@ def fetch_committee_names(congress, options):
     # This appears to be a mistake, a subcommittee appearing as a full committee. Map it to
     # the full committee for now.
     committee_names["House Antitrust (Full Committee Task Force)"] = committee_names["House Judiciary"]
+    committee_names["House Homeland Security"] = committee_names["House Homeland Security (Select)"]
+  if congress in range(108,113):
+    committee_names["House Intelligence"] = committee_names["House Intelligence (Permanent Select)"]
 
 def make_node(parent, tag, text, **attrs):
   """Make a node in an XML document."""

--- a/test/test_bill_actions.py
+++ b/test/test_bill_actions.py
@@ -428,7 +428,7 @@ class BillActions(unittest.TestCase):
 
     self.assertEqual(new_action['bill_ids'], ["hres241-109"])
 
-  def test_identify_committee(self):
+  def test_identify_committees(self):
     bill_id = "hr547-113"
     title = "To provide for the establishment of a border protection strategy for the international land borders of the United States, to address the ecological and environmental impacts of border security infrastructure, measures, and activities along the international land borders of the United States, and for other purposes."
     state = "INTRODUCED"
@@ -436,8 +436,8 @@ class BillActions(unittest.TestCase):
 
     new_action, new_state = bill_info.parse_bill_action(line, state, bill_id, title)
 
-    self.assertEqual(new_action['committee'], "House Homeland Security")
-    self.assertEqual(new_action['committee_id'], "HSHM")
+    self.assertIn("HSHM", new_action['committees'])
+    self.assertEqual(new_action['committees']["HSHM"], "House Homeland Security")
 
   def test_referral_committee(self):
     bill_id = "hr547-113"


### PR DESCRIPTION
Bill actions can have one or more committees referenced in the action. This places a "committees" entry in the "actions" object that contains a dict of committee id:name pairs. In practice, this only searches for the first instance because the regex findall method was not matching on single or multiple instances. 
