### PR TITLE
Added a timeout option for http reads.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ ipython
 lxml>=2.2
 pytz
 cssselect
-scrapelib
+scrapelib==0.9.1
 mechanize
+mock

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -198,6 +198,10 @@ def download(url, destination=None, options={}):
   # if need a POST request with data
   postdata = options.get('postdata', False)
 
+  urlopen_kwargs = slice_map(options, 'timeout')
+  if 'timeout' in urlopen_kwargs:
+      urlopen_kwargs['timeout'] = float(urlopen_kwargs['timeout']) # The low level socket api requires a float
+
   # caller cares about actually bytes or only success/fail
   needs_content = options.get('needs_content', True) or not is_binary or postdata
 
@@ -266,7 +270,7 @@ def download(url, destination=None, options={}):
       logging.info("Downloading: %s" % url)
 
       if postdata:
-        response = scraper.urlopen(url, 'POST', postdata)
+        response = scraper.urlopen(url, 'POST', postdata, **urlopen_kwargs)
       else:
 
         # If we're just downloading the file and the caller doesn't
@@ -292,7 +296,7 @@ def download(url, destination=None, options={}):
             os.unlink(cache_path)
             return None
 
-        response = scraper.urlopen(url)
+        response = scraper.urlopen(url, **urlopen_kwargs)
 
       if not is_binary:
         body = response # a subclass of a 'unicode' instance
@@ -585,6 +589,14 @@ def thomas_corrections(thomas_id):
   if thomas_id == "01594": thomas_id = "02085"
 
   return thomas_id
+
+# Return a subset of a mapping type
+def slice_map(m, *args):
+    n = {}
+    for arg in args:
+        if arg in m:
+            n[arg] = m[arg]
+    return n
 
 # Load a YAML file directly.
 def direct_yaml_load(filename):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,22 @@
+import unittest
+import bill_info
+import requests
+import mock
+import utils
+
+
+class UtilsTests(unittest.TestCase):
+
+  def test_timeout(self):
+    """
+    Ensures that the scrapelib library is properly passed and passes the
+    timeout parameter through to the requests library.
+    """
+    def raise_if_timeout_passed(*args, **kwargs):
+        if 'timeout' in kwargs:
+            raise requests.Timeout("Mocked timeout")
+
+    with mock.patch('requests.Session.request', raise_if_timeout_passed):
+        # This URL will never be accessed -- it just needs to be parseable
+        self.assertRaises(requests.Timeout, utils.download, 'http://localhost/', options={'timeout': 1})
+


### PR DESCRIPTION
I periodically see the bills scraper hang in a blocking call on the socket connected to Thomas. When it happens, the read will hang until the process is killed. This fixes it by allowing you to specify a read timeout on the command line. The read timeout support was added in scrapelib==0.9.1. If no `--timeout` option is passed to `run` the behavior should be unchanged.
