### PR TITLE
Windows 'which wget' command fixed in utils.py

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -282,12 +282,6 @@ def download(url, destination=None, options={}):
         # bill text files like PDFs.
         #
         # Skip this fast path if wget is not present in its expected location.
-
-        # if platform.system() == 'Windows':
-        #   wget_exists = (subprocess.call(["where wget > \\dev\\null"], shell=True) == 0)
-        # else:
-        #   wget_exists = (subprocess.call(["which wget > /dev/null"], shell=True) == 0)
-
         with open(os.devnull, 'w') as tempf:
           if platform.system() == 'Windows':
             wget_exists = (subprocess.call("where wget", stdout=tempf, stderr=tempf, shell=True) == 0)


### PR DESCRIPTION
On windows machines running the command which wget causes an error, so the command where wget is run instead in the utils.py download function. Fixes #120.
