### PR TITLE
update scrapelib to 0.10, remove follow_robots kwarg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ipython
 lxml>=2.2
 pytz
 cssselect
-scrapelib==0.9.1
+scrapelib>=0.10.0
 mechanize
 BeautifulSoup4
 mock

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -37,7 +37,7 @@ else:
 eastern_time_zone = timezone('US/Eastern')
 
 # scraper should be instantiated at class-load time, so that it can rate limit appropriately
-scraper = scrapelib.Scraper(requests_per_minute=120, follow_robots=False, retry_attempts=3)
+scraper = scrapelib.Scraper(requests_per_minute=120, retry_attempts=3)
 scraper.user_agent = "unitedstates/congress (https://github.com/unitedstates/congress)"
 
 


### PR DESCRIPTION
[scrapelib](https://github.com/sunlightlabs/scrapelib) updated to `0.10`, and removed the `follow_robots` parameter and default behavior.

Unfortunately, removing the follow_robots keyword and *not* updating to `0.10` has the effect of enforcing robots.txt checking, which stops this project in its tracks (it depends on ignoring robots.txt).

So after merging, **anyone with this deployed needs to re-run `pip install -r requirements.txt`**.

I'll leave it to a project owner to merge.