### PR TITLE
improved House amendment action regex

### DIFF
--- a/tasks/amendment_info.py
+++ b/tasks/amendment_info.py
@@ -286,7 +286,7 @@ def amendment_simple_text_for(body, heading):
 def parse_amendment_actions(actions):
     for action in actions:
         # House Vote
-        m = re.match(r"On agreeing to the .* amendment (\(.*\) )?(?:as amended )?(Agreed to|Failed) (without objection|by [^\.:]+|by (?:recorded vote|the Yeas and Nays): (\d+) - (\d+)(, \d+ Present)? \(Roll no. (\d+)\))\.", action['text'])
+        m = re.match(r"On agreeing to the .* amendments? (\(.*\) )?(?:as (?:modified|amended) )?(Agreed to|Failed) (without objection|by [^\.:]+|by (?:recorded vote|the Yeas and Nays): (\d+) - (\d+)(, \d+ Present)? \(Roll [nN]o. (\d+)\))\.", action['text'])
         if m:
             action["where"] = "h"
             action["type"] = "vote"

--- a/test/test_amendment_actions.py
+++ b/test/test_amendment_actions.py
@@ -1,0 +1,63 @@
+import unittest
+from amendment_info import parse_amendment_actions 
+import datetime
+
+# parsing various kinds of action text to extract metadata and establish state
+
+
+
+
+
+class AmendmentActions(unittest.TestCase):
+
+	def test_amendment_action_uses_amendments_plural(self): 
+		action = {
+			'text': 'On agreeing to the Poe amendments (A009) Failed by recorded vote: 141 - 279 (Roll no. 164).',
+			'type': 'action',
+			'references': [],
+			'acted_at': datetime.datetime(2005, 6, 17, 11, 16),
+		}
+		actions = [action]
+		parse_amendment_actions(actions)
+		action = actions[0]
+		self.assertEqual(action['where'], 'h')
+		self.assertEqual(action['type'], 'vote')
+		self.assertEqual(action['vote_type'], 'vote')
+		self.assertEqual(action['result'], 'fail')
+		self.assertEqual(action['how'], 'roll')
+		self.assertEqual(action['roll'], 164)
+
+	def test_amendment_action_uses_as_modified_instead_of_as_amended(self): 
+		action = {
+			'text': 'On agreeing to the Jackson-Lee (TX) amendment (A015) as modified Agreed to by recorded vote: 233 - 192 (Roll no. 412). (text as modified: CR H6290)',
+			'type': 'action',
+			'references': [],
+			'acted_at': datetime.datetime(2005, 6, 17, 11, 16),
+		}
+		actions = [action]
+		parse_amendment_actions(actions)
+		action = actions[0]
+		self.assertEqual(action['where'], 'h')
+		self.assertEqual(action['type'], 'vote')
+		self.assertEqual(action['vote_type'], 'vote')
+		self.assertEqual(action['result'], 'pass')
+		self.assertEqual(action['how'], 'roll')
+		self.assertEqual(action['roll'], 412)
+
+	def test_amendment_action_uses_capital_N_in_no(self): 
+		action = {
+			'text': 'On agreeing to the Capps amendment (A028) Failed by recorded vote: 213 - 219 (Roll No. 129).',
+			'type': 'action',
+			'references': [],
+			'acted_at': datetime.datetime(2005, 6, 17, 11, 16),
+		}
+		actions = [action]
+		parse_amendment_actions(actions)
+		action = actions[0]
+		self.assertEqual(action['where'], 'h')
+		self.assertEqual(action['type'], 'vote')
+		self.assertEqual(action['vote_type'], 'vote')
+		self.assertEqual(action['result'], 'fail')
+		self.assertEqual(action['how'], 'roll')
+		self.assertEqual(action['roll'], 129)
+


### PR DESCRIPTION
Improves House amendment action regex in parse_amendment_actions to catch three edge cases. 
1. Plural "amendments" (I guess sometimes they vote on the a package of amendments at once. Example: "On agreeing to the Poe amendments (A009) Failed by recorded vote: 141 - 279 (Roll no. 164)."
2. "as modified" instead of "as amended." Example: "On agreeing to the Jackson-Lee (TX) amendment (A015) as modified Agreed to by recorded vote: 233 - 192 (Roll no. 412). (text as modified: CR H6290)"
3. Capital "N" in "Roll No. 129". Example: "On agreeing to the Capps amendment (A028) Failed by recorded vote: 213 - 219 (Roll No. 129)."

added a test_amendment_actions.py file in test folder with tests for these three cases. I'm not sure if that's exactly how you would want it but if nothing else you can look at them to see the fix works. 

The regex amendments do not alter the grouping that is used later in the function to assign metadata to the action dict. 
