### PR TITLE
Add source url in JSON data

### DIFF
--- a/tasks/bill_info.py
+++ b/tasks/bill_info.py
@@ -216,6 +216,8 @@ def process_bill(bill_id, options,
         'bill_type': bill_type,
         'number': number,
         'congress': congress,
+        
+        'url': bill_url_for(bill_id),
 
         'introduced_at': introduced_at,
         'by_request': by_request,


### PR DESCRIPTION
It would be nice to have the url from which the data is scraped.