### PR TITLE
don't allow scrapelib 1.0 to be installed until urlopen calls are removed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ipython
 lxml>=2.2
 pytz
 cssselect
-scrapelib>=0.10.0
+scrapelib>=0.10.0,<1.0.0
 mechanize
 BeautifulSoup4
 mock


### PR DESCRIPTION
scrapelib 1.0 removes the deprecated urlopen method

this will prevent things from breaking until urlopen can be replaced