### PR TITLE
Fix Travis CI by dropping OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 
 os:
   - linux
-  - osx
 
 install: pip install -r requirements.txt
 script: python test/run


### PR DESCRIPTION
This issue suggests it's non-trivial for now:
https://github.com/travis-ci/travis-ci/issues/2312

But I have no idea why this only just started befalling us a few builds ago.