### PR TITLE
Use scrapelib.urlretrieve()

### DIFF
--- a/tasks/fdsys.py
+++ b/tasks/fdsys.py
@@ -402,8 +402,7 @@ def mirror_package_or_granule(sitemap, package_name, granule_name, lastmod, opti
             'force': True, # decision to cache was made above
             'to_cache': False,
             'return_status_code_on_error': True,
-            # an old optimization, but it conflicts with return_status_code_on_error
-            #'needs_content': (file_type == "text" and file_path.endswith(".html")),
+            'needs_content': (file_type == "text" and file_path.endswith(".html")),
         }))
 
         # Download failed?

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -307,32 +307,10 @@ def download(url, destination=None, options={}):
             if postdata:
                 response = scraper.urlopen(url, 'POST', postdata, **urlopen_kwargs)
             else:
-
-                # If we're just downloading the file and the caller doesn't
-                # need the response data, then starting wget to download the
-                # file is much faster for large files. Don't know why. Something
-                # hopefully we can improve in scrapelib in the future.
-                #
-                # needs_content is currently only set to false when downloading
-                # bill text files like PDFs.
-                #
-                # Skip this fast path if wget is not present in its expected location.
-                with open(os.devnull, 'w') as tempf:
-                    if platform.system() == 'Windows':
-                        wget_exists = (subprocess.call("where wget", stdout=tempf, stderr=tempf, shell=True) == 0)
-                    else:
-                        wget_exists = (subprocess.call("which wget", stdout=tempf, stderr=tempf, shell=True) == 0)
-
-                if not needs_content and wget_exists:
-
+                if not needs_content:
                     mkdir_p(os.path.dirname(cache_path))
-                    if subprocess.call(["wget", "-q", "-O", cache_path, url]) == 0:
-                        return True
-                    else:
-                        # wget failed. when that happens it leaves a zero-byte file on disk, which
-                        # for us means we've created an invalid file, so delete it.
-                        os.unlink(cache_path)
-                        return None
+                    scraper.urlretrieve(url, cache_path, **urlopen_kwargs)
+                    return True
 
                 response = scraper.urlopen(url, **urlopen_kwargs)
 


### PR DESCRIPTION
This is a follow-up of sorts from unitedstates/inspectors-general#149. `scrapelib.urlopen()` runs the entire response through `chardet`, which takes a long time on large binary files. This happens because `urlopen()` touches the `text` property defined by `requests`, which in turn runs `chardet` if the `encoding` property hasn't been set yet. Using `scrapelib.urlretrieve()` instead of `scrapelib.urlopen()` sidesteps the whole issue, see jamesturk/scrapelib#21.

In this PR, I replaced shelling out to `wget` with using `urlretrieve()`, which should be faster, since it runs in the same process. Moreover, `urlretreive()` raises exceptions on HTTP errors, which means the FDsys scraper can use the optimized path again, since that scraper depends on getting HTTP error codes back.