### PR TITLE
Handle .DS_Store files

### DIFF
--- a/tasks/bills.py
+++ b/tasks/bills.py
@@ -69,12 +69,17 @@ def get_bills_to_process(options):
 
         # walk through all bill types in that congress
         # (sort by bill type so that we proceed in a stable order each run)
-        for bill_type in sorted(os.listdir(get_data_path(congress))):
+
+        bill_types = [bill_type for bill_type in os.listdir(get_data_path(congress)) if not bill_type.startswith(".")]
+
+        for bill_type in sorted(bill_types):
 
             # walk through each bill in that congress and bill type
             # (sort by bill number so that we proceed in a normal order)
+
+            bills = [bill for bill in os.listdir(get_data_path(congress, bill_type)) if not bill.startswith(".")]
             for bill_type_and_number in sorted(
-                os.listdir(get_data_path(congress, bill_type)),
+                bills,
                 key = lambda x : int(x.replace(bill_type, ""))
                 ):
 

--- a/tasks/bills.py
+++ b/tasks/bills.py
@@ -142,16 +142,6 @@ def form_bill_json_dict(xml_as_dict):
     actions = bill_info.actions_for(bill_dict['actions']['item'], bill_id, bill_info.current_title_for(titles, 'official'))
     status, status_date = bill_info.latest_status(actions, bill_dict.get('introducedDate', ''))
 
-    policy_area = None
-    policy_areas = []
-    if bill_dict.has_key('policyArea') and bill_dict['policyArea']:
-        policy_area = _fixup_top_term_case(bill_dict['policyArea']['name'])
-        policy_areas = [policy_area]
-
-    subjects_list=[]
-    if bill_dict['subjects']['billSubjects'].has_key('legislativeSubjects') and bill_dict['subjects']['billSubjects']['legislativeSubjects']:
-        subjects_list = [item['name'] for item in bill_dict['subjects']['billSubjects']['legislativeSubjects']['item']]
-
     bill_data = {
         'bill_id': bill_id,
         'bill_type': bill_dict.get('billType').lower(),
@@ -181,10 +171,11 @@ def form_bill_json_dict(xml_as_dict):
         # The top term's case has changed with the new bulk data. It's now in
         # Title Case. For backwards compatibility, the top term is run through
         # '.capitalize()' so it matches the old string. TODO: Remove one day?
-        'subjects_top_term': policy_area,
+        'subjects_top_term': _fixup_top_term_case(bill_dict['policyArea']['name']) if bill_dict['policyArea'] else None,
         'subjects':
             sorted(
-                (policy_areas) + (subjects_list)
+                ([_fixup_top_term_case(bill_dict['policyArea']['name'])] if bill_dict['policyArea'] else []) +
+                ([item['name'] for item in bill_dict['subjects']['billSubjects']['legislativeSubjects']['item']] if bill_dict['subjects']['billSubjects']['legislativeSubjects'] else [])
             ),
 
         'related_bills': bill_info.related_bills_for(bill_dict['relatedBills']),

--- a/tasks/bills.py
+++ b/tasks/bills.py
@@ -142,6 +142,16 @@ def form_bill_json_dict(xml_as_dict):
     actions = bill_info.actions_for(bill_dict['actions']['item'], bill_id, bill_info.current_title_for(titles, 'official'))
     status, status_date = bill_info.latest_status(actions, bill_dict.get('introducedDate', ''))
 
+    policy_area = None
+    policy_areas = []
+    if bill_dict.has_key('policyArea') and bill_dict['policyArea']:
+        policy_area = _fixup_top_term_case(bill_dict['policyArea']['name'])
+        policy_areas = [policy_area]
+
+    subjects_list=[]
+    if bill_dict['subjects']['billSubjects'].has_key('legislativeSubjects') and bill_dict['subjects']['billSubjects']['legislativeSubjects']:
+        subjects_list = [item['name'] for item in bill_dict['subjects']['billSubjects']['legislativeSubjects']['item']]
+
     bill_data = {
         'bill_id': bill_id,
         'bill_type': bill_dict.get('billType').lower(),
@@ -171,11 +181,10 @@ def form_bill_json_dict(xml_as_dict):
         # The top term's case has changed with the new bulk data. It's now in
         # Title Case. For backwards compatibility, the top term is run through
         # '.capitalize()' so it matches the old string. TODO: Remove one day?
-        'subjects_top_term': _fixup_top_term_case(bill_dict['policyArea']['name']) if bill_dict['policyArea'] else None,
+        'subjects_top_term': policy_area,
         'subjects':
             sorted(
-                ([_fixup_top_term_case(bill_dict['policyArea']['name'])] if bill_dict['policyArea'] else []) +
-                ([item['name'] for item in bill_dict['subjects']['billSubjects']['legislativeSubjects']['item']] if bill_dict['subjects']['billSubjects']['legislativeSubjects'] else [])
+                (policy_areas) + (subjects_list)
             ),
 
         'related_bills': bill_info.related_bills_for(bill_dict['relatedBills']),

--- a/tasks/fdsys.py
+++ b/tasks/fdsys.py
@@ -32,13 +32,12 @@
 #   year).
 #
 #   --congress=113[,114]
-#   Comma-separated list of congresses to download from (does not
-#   apply to bulk data collections which are not divided by
-#   congress). Alternate format:
+#   Comma-separated list of congresses to download from (only for
+#   BILLSTATUS). Alternate format:
 #
 #   --congress=">113"
-#   Specify a number to get all congresses *after* the value. The
-#   quotes are necessary for this format.
+#   Specify a number to get all congresses *after* the value (only for
+#   BILLSTATUS) The quotes are necessary for this format.
 #
 #   --store=mods,pdf,text,xml,premis
 #   Save the MODS, PDF, text, XML, or PREMIS file associated
@@ -250,7 +249,7 @@ def extract_sitemap_subject_from_url(url, how_we_got_here):
     if m:
         return_data = { "bulkdata": True, "collection": m.group(1), "grouping": m.group(2) }
         congress_match = re.match(r"^([0-9]+)", m.group(2))
-        if congress_match:
+        if return_data["collection"] == "BILLSTATUS" and congress_match:
             return_data['congress'] = congress_match.group(1)
 
         return return_data


### PR DESCRIPTION
I ran into an issue where moving folders around in OS X was creating .DS_Store files, and when the system tried to parse those it died:

```
Traceback (most recent call last):
  File "./import.py", line 72, in <module>
    for id in to_fetch:
  File "/Users/krues8dr/Sites/xcential.localhost/bill-importer/congress/tasks/bills.py", line 81, in get_bills_to_process
    key = lambda x : int(x.replace(bill_type, ""))
  File "/Users/krues8dr/Sites/xcential.localhost/bill-importer/congress/tasks/bills.py", line 81, in <lambda>
    key = lambda x : int(x.replace(bill_type, ""))
ValueError: invalid literal for int() with base 10: '.DS_Store'
```

and

```
Traceback (most recent call last):
  File "./import.py", line 72, in <module>
    for id in to_fetch:
  File "/Users/krues8dr/Sites/xcential.localhost/bill-importer/congress/tasks/bills.py", line 77, in get_bills_to_process
    bills = [bill for bill in os.listdir(get_data_path(congress, bill_type)) if not bill.startswith(".")]
OSError: [Errno 20] Not a directory: 'data/114/bills/.DS_Store'
```

We should probably be doing closer checks to make sure that items are actually directories and properly-named folders, but this is a first step that scratches my itch.