### PR TITLE
fix broken fdsys, vote category parsing regex tweaks

### DIFF
--- a/tasks/fdsys.py
+++ b/tasks/fdsys.py
@@ -455,6 +455,12 @@ def mirror_package_or_granule(sitemap, package_name, granule_name, lastmod, opti
             elif sitemap["collection"] == "BILLS" and file_type in ("text", "mods"):
                 # expected to be present for bills
                 raise Exception("Failed to download %s %s (404)" % (package_name, file_type))
+        elif data is True:
+            # Download was successful but needs_content was False so we don't have the
+            # file content. Instead, True is returned. Strangely isintance(True, int) is
+            # True (!!!) so we have to test for True separately from testing if we got a
+            # return code integer.
+            pass
         elif not data or isinstance(data, int):
             # There was some other error - skip the rest. Don't
             # update file_lastmod!

--- a/tasks/vote_info.py
+++ b/tasks/vote_info.py
@@ -483,7 +483,7 @@ def get_vote_category(vote_question):
         # common
         (r"^On Overriding the Veto", "veto-override"),
         (r"^On Presidential Veto", "veto-override"),
-        (r"Objections of the President Not ?Withstanding", "veto-override"),  # order matters so must go before bill passage
+        (r"Objections of the President (To The Contrary )?Not ?Withstanding", "veto-override"),  # order matters so must go before bill passage
         (r"^On Passage", "passage"),
         (r"^On the Resolution of Ratification.*", "treaty"), # order matters so must go before other resolutions
         (r"^On (Agreeing to )?the (Joint |Concurrent )?Resolution", "passage"),
@@ -498,7 +498,7 @@ def get_vote_category(vote_question):
         (r"^On the Motion \(Motion to Concur", "passage"),
 
         # house only
-        (r"^(On Motion (to|that the House) )?(Concur in|Concurring|Concurring in|On Concurring|Agree to|On Agreeing to) (the )?Senate (Amendment|amdt|Adt)s?", "passage"),
+        (r"^(On Motion (to|that the House) )?(Concur in|Concurring|Concurring in|On Concurring|On Concurring in|Agree to|On Agreeing to) (the )?Senate (Amendment|amdt|Adt)s?", "passage"),
         (r"^(On Motion to )?Suspend (the )?Rules and (Agree|Concur|Pass)", "passage-suspension"),
         (r"^Call of the House$", "quorum"),
         (r"^Call by States$", "quorum"),
@@ -515,6 +515,7 @@ def get_vote_category(vote_question):
         (r"^On .*Motion ", "procedural"),  # $1 is a name like "Broun of Georgia"
         (r"^On the Decision of the Chair", "procedural"),
         (r"^Whether the Amendment is Germane", "procedural"),
+        (r"^Table Appeal of the Ruling of the Chair", "procedural"),
     )
 
     for regex, category in mapping:


### PR DESCRIPTION
First commit: #179 broke the fdsys scraper.

Second commit: Tweaking regexes in the vote category parser.