### PR TITLE
drop THOMAS IDs from output, replace with bioguide in XML outputs

### DIFF
--- a/tasks/amendment_info.py
+++ b/tasks/amendment_info.py
@@ -100,11 +100,11 @@ def create_govtrack_xml(amdt, options):
     make_node(root, "status", amdt['status'], datetime=amdt['status_at'])
 
     if amdt['sponsor'] and amdt['sponsor']['type'] == 'person':
-        v = amdt['sponsor']['thomas_id']
+        v = amdt['sponsor']['bioguide_id']
         if not options.get("govtrack", False):
-            make_node(root, "sponsor", None, thomas_id=v)
+            make_node(root, "sponsor", None, bioguide_id=v)
         else:
-            v = str(utils.translate_legislator_id('thomas', v, 'govtrack'))
+            v = str(utils.translate_legislator_id('bioguide', v, 'govtrack'))
             make_node(root, "sponsor", None, id=v)
     elif amdt['sponsor'] and amdt['sponsor']['type'] == 'committee':
         make_node(root, "sponsor", None, committee=amdt['sponsor']['name'])

--- a/tasks/bill_info.py
+++ b/tasks/bill_info.py
@@ -17,14 +17,14 @@ def create_govtrack_xml(bill, options):
 
     def make_node(parent, tag, text, **attrs):
         if options.get("govtrack", False):
-            # Rewrite thomas_id attributes as just id with GovTrack person IDs.
+            # Rewrite bioguide_id attributes as just id with GovTrack person IDs.
             attrs2 = {}
             for k, v in attrs.items():
                 if v:
-                    if k == "thomas_id":
-                        # remap "thomas_id" attributes to govtrack "id"
+                    if k == "bioguide_id":
+                        # remap "bioguide_id" attributes to govtrack "id"
                         k = "id"
-                        v = str(utils.translate_legislator_id('thomas', v, 'govtrack'))
+                        v = str(utils.translate_legislator_id('bioguide', v, 'govtrack'))
                     attrs2[k] = v
             attrs = attrs2
 
@@ -59,13 +59,13 @@ def create_govtrack_xml(bill, options):
 
     if bill['sponsor']:
         # TODO: Sponsored by committee?
-        make_node(root, "sponsor", None, thomas_id=bill['sponsor']['thomas_id'])
+        make_node(root, "sponsor", None, bioguide_id=bill['sponsor']['bioguide_id'])
     else:
         make_node(root, "sponsor", None)
 
     cosponsors = make_node(root, "cosponsors", None)
     for cosp in bill['cosponsors']:
-        n = make_node(cosponsors, "cosponsor", None, thomas_id=cosp["thomas_id"])
+        n = make_node(cosponsors, "cosponsor", None, bioguide_id=cosp["bioguide_id"])
         if cosp["sponsored_at"]:
             n.set("joined", cosp["sponsored_at"])
         if cosp["withdrawn_at"]:
@@ -166,7 +166,6 @@ def sponsor_for(sponsor_dict):
         'district': district,
         'state': m.group('state'),
         #'party': m.group('party'),
-        'thomas_id': utils.translate_legislator_id('bioguide', sponsor_dict['bioguideId'], 'thomas'),  # TODO: Remove one day.
         'bioguide_id': sponsor_dict['bioguideId'],
         'type': 'person'
     }

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -579,20 +579,6 @@ def make_node(parent, tag, text, **attrs):
         n.set(k.replace("___", ""), v)
     return n
 
-# Correct mistakes on THOMAS
-
-
-def thomas_corrections(thomas_id):
-
-    # C.A. Dutch Ruppersberger
-    if thomas_id == "02188":
-        thomas_id = "01728"
-
-    # Pat Toomey
-    if thomas_id == "01594":
-        thomas_id = "02085"
-
-    return thomas_id
 
 # Return a subset of a mapping type
 


### PR DESCRIPTION
Our JSON and XML outputs for bills and amendments includes the THOMAS ids for sponsors and cosponsors. I think I kept it in the switch to the FDSys bulk data to remain as compatible as possible with earlier data files.

But..... Legislators are no longer getting THOMAS IDs. (Rep. Comer, who was recently sworn in, has cosponsored a bill, but has no THOMAS ID, and our scraper now fails on hconres17 because of it.) 

This:

* Removes all THOMAS IDs in output. We have bioguide ID fields in the same places.
* In the bill/amendment XML output, which I think I am the only consumer of, I replaced the thomas_id attribute with a bioguide_id attribute.
* There's some code changes in the GovTrack XML-specific code path (there's a `--govtrack` flag) that's just switching the THOMAS=>GovTrack ID conversion to be Bioguide=>GovTrack.