### PR TITLE
Fix NoneType getitem error in relation to sponsors

### DIFF
--- a/tasks/bills.py
+++ b/tasks/bills.py
@@ -156,8 +156,8 @@ def form_bill_json_dict(xml_as_dict):
         'url': billstatus_url_for(bill_id),
 
         'introduced_at': bill_dict.get('introducedDate', ''),
-        'by_request': bill_dict['sponsors']['item'][0]['byRequestType']     is not None,
-        'sponsor': bill_info.sponsor_for(bill_dict['sponsors']['item'][0]),
+        'by_request': (bill_dict['sponsors']['item'][0]['byRequestType'] if bill_dict['sponsors'] is not None else False),
+        'sponsor': (bill_info.sponsor_for(bill_dict['sponsors']['item'][0]) if bill_dict['sponsors'] is not None else {}),
         'cosponsors': bill_info.cosponsors_for(bill_dict['cosponsors']),
 
         'actions': actions,


### PR DESCRIPTION
After running

```
./run fdsys --collections=BILLSTATUS
```
I ran
```
./run bills
```
and got numerous errors on lines 159 and 160 regarding a non existing `sponsors` element which prevented the JSON from being saved. By making sure that `sponsors` exists - otherwise setting `False` or an empty object - the JSON is saved/updated successfully.

I'm not sure if I should look further back to see what is causing the issue, but this seemed to do the trick.