### PR TITLE
Remove sudo from commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ brew install wget
 
 **Python dependencies**
 
-It's recommended you use a `virtualenv` (virtual environment) for development. The easiest way is install `virtualenv` and `virtualenvwrapper`, using `sudo` if necessary:
+It's recommended you use a `virtualenv` (virtual environment) for development. The easiest way is install `virtualenv` and `virtualenvwrapper` (using `sudo` if necessary):
 
 ```bash
-sudo pip install virtualenv
-sudo pip install virtualenvwrapper
+pip install virtualenv
+pip install virtualenvwrapper
 ```
 
 Create a virtualenv for this project:


### PR DESCRIPTION
We already say to include `sudo` if necessary right before, so we don't need to include it in the shown command. Much better to err on the side of less permissions and let the user decide when/if it's appropriate to run `sudo` during installation of third party code.

Fixes #195.