### PR TITLE
changed utils.admin(exception) to print exception

### DIFF
--- a/run
+++ b/run
@@ -70,4 +70,4 @@ try:
 
     task_mod.run(options)
 except Exception as exception:
-    utils.admin(exception)
+    print exception


### PR DESCRIPTION
File "run", line 73, in <module>                                                                                                                                  
    utils.admin(exception)                                                                                                                                               
AttributeError: 'module' object has no attribute 'admin'

utils doesn't seem to have admin 