### PR TITLE
Remove ipython from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pyyaml
 iso8601==0.1.4
 python-dateutil==1.5
-ipython
 lxml>=2.2
 pytz
 cssselect


### PR DESCRIPTION
Remove ipython from the requirements.txt file because:

1. IPython is not used anywhere in the repository
2. IPython 6+ is not compatible with Python 2.7

Issue: #224 