### PR TITLE
switch fdsys scraper from fdsys to govinfo.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ where data-type is one of:
 * `votes` (see [Votes](https://github.com/unitedstates/congress/wiki/votes))
 * `nominations` (see [Nominations](https://github.com/unitedstates/congress/wiki/nominations))
 * `committee_meetings` (see [Committee Meetings](https://github.com/unitedstates/congress/wiki/committee-meetings))
-* `fdsys` (see [Bill Text](https://github.com/unitedstates/congress/wiki/bill-text))
+* `govinfo` (see [Bill Text](https://github.com/unitedstates/congress/wiki/bill-text))
 * `statutes` (see [Bills](https://github.com/unitedstates/congress/wiki/bills) and [Bill Text](https://github.com/unitedstates/congress/wiki/bill-text))
 
 To get data for bills, resolutions, and amendments, run:
 
 ```bash
-./run fdsys --bulkdata=BILLSTATUS
+./run govinfo --bulkdata=BILLSTATUS
 ./run bills
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Includes:
 
 * Scrapers for House and Senate roll call votes.
 
-* A scraper for GPO FDSys, the official repository for most legislative documents.
+* A document fetcher for GovInfo.gov, which holds bill text, bill status, and other official documents.
 
 * A defunct THOMAS scraper for presidential nominations in Congress.
 
@@ -77,10 +77,10 @@ where data-type is one of:
 * `fdsys` (see [Bill Text](https://github.com/unitedstates/congress/wiki/bill-text))
 * `statutes` (see [Bills](https://github.com/unitedstates/congress/wiki/bills) and [Bill Text](https://github.com/unitedstates/congress/wiki/bill-text))
 
-To scrape bills, resolutions, and amendments from THOMAS, run:
+To get data for bills, resolutions, and amendments, run:
 
 ```bash
-./run fdsys --collections=BILLSTATUS
+./run fdsys --bulkdata=BILLSTATUS
 ./run bills
 ```
 

--- a/scripts/bills.sh
+++ b/scripts/bills.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Refresh the bulk data collection.
-./run fdsys --bulkdata=True --collections=BILLSTATUS
+./run govinfo --bulkdata=BILLSTATUS
 
 # Turn into JSON and GovTrack-XML.
 ./run bills --govtrack $@

--- a/scripts/statutes.sh
+++ b/scripts/statutes.sh
@@ -1,3 +1,3 @@
-./run fdsys --collections=STATUTE --store=mods,pdf
+./run govinfo --collections=STATUTE --extract=mods,pdf
 ./run statutes --volumes=65-86 --govtrack # bill status
 ./run statutes --volumes=65-106 --textversions --extracttext # bill text

--- a/tasks/bills.py
+++ b/tasks/bills.py
@@ -6,7 +6,7 @@ import xmltodict
 
 import bill_info
 import amendment_info
-import fdsys
+import govinfo
 import utils
 
 
@@ -34,7 +34,7 @@ def get_bills_to_process(options):
     # Return a generator over bill_ids that need to be processed.
     # Every time we process a bill we copy the fdsys_billstatus-lastmod.txt
     # file to data-fromfdsys-lastmod.txt, next to data.json. This way we
-    # know when the FDSys XML file has changed.
+    # know when the GovInfo (formerly FDSys) XML file has changed.
 
     def get_data_path(*args):
         # Utility function to generate a part of the path
@@ -83,9 +83,9 @@ def get_bills_to_process(options):
                 key = lambda x : int(x.replace(bill_type, ""))
                 ):
 
-                fn = get_data_path(congress, bill_type, bill_type_and_number, fdsys.FDSYS_BILLSTATUS_FILENAME)
+                fn = get_data_path(congress, bill_type, bill_type_and_number, govinfo.FDSYS_BILLSTATUS_FILENAME)
                 if os.path.exists(fn):
-                    # The FDSys bulk data file exists. Does our JSON data
+                    # The GovInfo.gov bulk data file exists. Does our JSON data
                     # file need to be updated?
                     bulkfile_lastmod = utils.read(fn.replace(".xml", "-lastmod.txt"))
                     parse_lastmod = utils.read(get_data_path(congress, bill_type, bill_type_and_number, "data-fromfdsys-lastmod.txt"))
@@ -125,7 +125,7 @@ def process_bill(bill_id, options):
     }
 
 def _path_to_billstatus_file(bill_id):
-    return output_for_bill(bill_id, fdsys.FDSYS_BILLSTATUS_FILENAME, is_data_dot=False)
+    return output_for_bill(bill_id, govinfo.FDSYS_BILLSTATUS_FILENAME, is_data_dot=False)
 
 def read_fdsys_bulk_bill_status_file(fn, bill_id):
     fdsys_billstatus = utils.read(fn)
@@ -203,7 +203,7 @@ def build_bill_id(bill_type, bill_number, congress):
 
 def billstatus_url_for(bill_id):
     bill_type, bill_number, congress = utils.split_bill_id(bill_id)
-    return fdsys.BULKDATA_BASE_URL + 'BILLSTATUS/{0}/{1}/BILLSTATUS-{0}{1}{2}.xml'.format(congress, bill_type, bill_number)
+    return govinfo.BULKDATA_BASE_URL + 'BILLSTATUS/{0}/{1}/BILLSTATUS-{0}{1}{2}.xml'.format(congress, bill_type, bill_number)
 
 def output_for_bill(bill_id, format, is_data_dot=True):
     bill_type, number, congress = utils.split_bill_id(bill_id)

--- a/tasks/govinfo.py
+++ b/tasks/govinfo.py
@@ -3,12 +3,12 @@
 # https://www.govinfo.gov/sitemaps for a list of collections.
 # This service was formerly called "Fdsys."
 #
-# ./run fdsys --collections=BILLS,STATUTE,...
+# ./run govinfo--collections=BILLS,STATUTE,...
 # Download bill text (from the BILLS collection; there's also a bulk
 # data BILLS collection but it has less in it), the Statues at Large,
 # and other documents from GovInfo.gov's non-bulk-data collections.
 #
-# ./run fdsys --bulkdata=BILLSTATUS,FR,...
+# ./run govinfo --bulkdata=BILLSTATUS,FR,...
 # Download bill status, the Federal Register, and other documents
 # from GovInfo.gov's bulk data collections. (The BILLS collection occurs
 # both as a regular collection (bill text in multiple formats) and as
@@ -89,7 +89,7 @@ def update_sitemap(url, current_lastmod, how_we_got_here, options):
     # * its <lastmod> date (which comes from the parent sitemap) so we know if we need to re-download it now
     # * the <lastmod> dates of the packages listed in this sitemap so we know if we need to re-download any package files
     cache_file = get_sitemap_cache_file(url)
-    cache_file = os.path.join("fdsys/sitemap", cache_file, "sitemap.xml")
+    cache_file = os.path.join("govinfo/sitemap", cache_file, "sitemap.xml")
     lastmod_cache_file = cache_file.replace(".xml", "-lastmod.yaml")
     lastmod_cache_file = os.path.join(utils.cache_dir(), lastmod_cache_file)
     if not os.path.exists(lastmod_cache_file):
@@ -272,7 +272,7 @@ def should_download_sitemap(lastmod_cache, current_lastmod, options):
 
 
 def mirror_package(collection, package_name, lastmod, lastmod_cache, options):
-    """Create a local mirror of a FDSys package."""
+    """Create a local mirror of a GovInfo.gov package."""
 
     # Where should we store the file? Each collection has a different
     # file system layout (for BILLS, we put bill text along where the
@@ -445,8 +445,8 @@ def get_output_path(collection, package_name, options):
         return "%s/%s/%s/%s/%s" % (utils.data_dir(), congress, collection.lower(), report_type, report_type + report_number)
     
     else:
-        # Store in fdsys/COLLECTION/PKGNAME.
-        path = "%s/fdsys/%s/%s" % (utils.data_dir(), collection, package_name)
+        # Store in govinfo/COLLECTION/PKGNAME.
+        path = "%s/govinfo/%s/%s" % (utils.data_dir(), collection, package_name)
         return path
 
 
@@ -463,7 +463,7 @@ def mirror_bulkdata_file(collection, url, item_path, lastmod, options):
     results = []
 
     # Where should we store the file?
-    path = "%s/fdsys/%s/%s" % (utils.data_dir(), collection, item_path)
+    path = "%s/govinfo/%s/%s" % (utils.data_dir(), collection, item_path)
 
     # For BILLSTATUS, store this along with where we store the rest of bill
     # status data.


### PR DESCRIPTION
This is a work-in-progress to get feedback from anyone using the fdsys scraper. If I'm the only one using it, I'll just merge this once I have it working right in production on GovTrack.

GPO's Fdsys is being turned off at the end of the calendar year. GovInfo.gov, its replacement, is very similar but the sitemaps are organized a little differently and granules (which I used for getting Statutes at Large per-law PDFs) must be scraped diffrently.

Because the sitemap layout changed from being organized by year first and collection second to collection first and year second, I simplified the code a bit and as a result some output paths are different:

* The sitemap cache files have a totally new structure. Deleting the old files in cache/fdsys/sitemap is probably a good idea.
* "Granules" are no longer scraped. (I am fairly certain I'm the only person who even knows what this is.)
* Besides BILLS (bill text) and CRPT (committee reports), which have had hard-coded output paths that aren't changed in this commit, for other regular collections the output path has changed from data/fdsys/COLLECTION/YEAR/PACKAGAE to just data/fdsys/COLLECTION/PACKAGAE (i.e. omitting year).
* Documents are downloaded more reliably by grabbing the entire package ZIP file for each package and then extracting the documents within it as needed (see below), rather than downloading the individual document files, because not every package has every document format and it's unclear how to know if a package doesn't have a format or if the download failed for that format.

The command-line arguments have also changed:

* Rather than adding `--bulkdata` to indicate that the collections are bulk data collections, `--bulkdata=BILLS,BILLSTATUS,...` is used to specify the bulk data collections you want to download. This allows you to fetch both regular and bulk data collections in one run.
* `--list` is no longer supported since I don't see a URL to a top-level sitemap that lists all of the collection sitemaps. See https://www.govinfo.gov/sitemaps for a list of sitemap codes.
* In order to simplify the code, `--congress=">113"` syntax is no longer supported.
* `--store` is changed to `--extract` to reflect that the operation is now extracting document formats from the package ZIP, which is always saved and stored in the data directory.