### PR TITLE
Fixes #243 - Bills.py TypeError from missing sponsors

### DIFF
--- a/tasks/bills.py
+++ b/tasks/bills.py
@@ -156,8 +156,8 @@ def form_bill_json_dict(xml_as_dict):
         'url': billstatus_url_for(bill_id),
 
         'introduced_at': bill_dict.get('introducedDate', ''),
-        'by_request': bill_dict['sponsors']['item'][0]['byRequestType']     is not None,
-        'sponsor': bill_info.sponsor_for(bill_dict['sponsors']['item'][0]),
+        'by_request': bool(bill_dict['sponsors']['item'][0]['byRequestType'] != None) if bill_dict['sponsors'] != None else False,
+        'sponsor': bill_info.sponsor_for(bill_dict['sponsors']['item'][0]) if bill_dict['sponsors'] != None else '',
         'cosponsors': bill_info.cosponsors_for(bill_dict['cosponsors']),
 
         'actions': actions,
@@ -220,4 +220,3 @@ def process_amendments(bill_id, bill_amendments, options):
 
     for amdt in amdt_list['amendment']:
         amendment_info.process_amendment(amdt, bill_id, options)
-

--- a/tasks/bills.py
+++ b/tasks/bills.py
@@ -157,7 +157,7 @@ def form_bill_json_dict(xml_as_dict):
 
         'introduced_at': bill_dict.get('introducedDate', ''),
         'by_request': bool(bill_dict['sponsors']['item'][0]['byRequestType'] != None) if bill_dict['sponsors'] != None else False,
-        'sponsor': bill_info.sponsor_for(bill_dict['sponsors']['item'][0]) if bill_dict['sponsors'] != None else '',
+        'sponsor': bill_info.sponsor_for(bill_dict['sponsors']['item'][0]) if bill_dict['sponsors'] != None else None,
         'cosponsors': bill_info.cosponsors_for(bill_dict['cosponsors']),
 
         'actions': actions,


### PR DESCRIPTION
Fixes #243 
Apparently bills are sometimes posted without sponsors (see sjres10-113 and s1696-113). This PR handles setting 'by_request' and 'sponsor' in bills.py so it does not error out if no sponsors are listed for a bill.