### PR TITLE
Use yaml.BaseLoader when loading config

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -30,7 +30,7 @@ path = "config.yml"
 if os.path.exists(path):
     # Don't use a cached config file, just in case, and direct_yaml_load is not yet defined.
     import yaml
-    config = yaml.load(open(path))
+    config = yaml.load(open(path), Loader=yaml.BaseLoader)
 else:
     config = None
 


### PR DESCRIPTION
I was getting this error when running the tool:

`[...]/unitedstates/congress/tasks/utils.py:33: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.`

This change specifies a loader so we don't get this deprecation message anymore. Seemed like `BaseLoader` was all we needed here. Some more info [here](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation#how-to-disable-the-warning).