### PR TITLE
Yaml safe-loader for Beanstalk contrib processing

### DIFF
--- a/contrib/beanstalkd.py
+++ b/contrib/beanstalkd.py
@@ -55,7 +55,7 @@ def init_guard(reconnect=False):
     global _Config, _Connection
     if _Config is None:
         with open('config.yml', 'r') as conffile:
-            config = yaml.load(conffile)
+            config = yaml.load(conffile, yaml.SafeLoader)
             assert 'beanstalk' in config
             assert 'connection' in config['beanstalk']
             assert 'host' in config['beanstalk']['connection']


### PR DESCRIPTION
New(ish) versions of PyYAML force you to be explicit about which Loader you wish to use (i.e. "the one that can execute code" or "the one that doesn't"). Since there's nothing special special about the `config.yml` here, we can use the boring one.

Failure to specify a loader will _raise an exception_ in current PyYAML.