### PR TITLE
Fix several run bill issues

### DIFF
--- a/tasks/bill_info.py
+++ b/tasks/bill_info.py
@@ -163,7 +163,7 @@ def sponsor_for(sponsor_dict):
         return None
 
     # TODO: Don't do regex matching here. Find another way.
-    m = re.match(r'(?P<title>(Rep\.|Sen\.|Del\.|Resident Commissioner)) (?P<name>.*?) +\[(?P<party>[DRIL])-(?P<state>[A-Z][A-Z])(-(?P<district>\d{1,2}|At Large|None))?\]$',
+    m = re.match(r'(?P<title>(Rep\.|Sen\.|Del\.|Resident Commissioner)) (?P<name>.*?) +\[(?P<party>[A-Z]+)-(?P<state>[A-Z][A-Z])(-(?P<district>\d{1,2}|At Large|None))?\]$',
         sponsor_dict['fullName'])
 
     if not m:

--- a/tasks/bill_info.py
+++ b/tasks/bill_info.py
@@ -394,7 +394,7 @@ def actions_for(action_list, bill_id, title):
 
         keep = True
         if closure['prev']:
-            if item['sourceSystem']['code'] == "9":
+            if 'sourceSystem' in item and item['sourceSystem']['code'] == "9":
                 # Date must match previous action..
                 # If both this and previous have a time, the times must match.
                 # The text must approximately match. Sometimes the LOC text has a prefix

--- a/tasks/bills.py
+++ b/tasks/bills.py
@@ -171,8 +171,8 @@ def form_bill_json_dict(xml_as_dict):
         'url': billstatus_url_for(bill_id),
 
         'introduced_at': bill_dict.get('introducedDate', ''),
-        'by_request': bill_dict['sponsors']['item'][0]['byRequestType']     is not None,
-        'sponsor': bill_info.sponsor_for(bill_dict['sponsors']['item'][0]),
+        'by_request': bill_dict['sponsors']['item'][0]['byRequestType'] is not None if bill_dict['sponsors'] != None else False,
+        'sponsor': bill_info.sponsor_for(bill_dict['sponsors']['item'][0]) if bill_dict['sponsors'] != None else None,
         'cosponsors': bill_info.cosponsors_for(bill_dict['cosponsors']),
 
         'actions': actions,


### PR DESCRIPTION
1. This fixes an issue in the parsing regex for a sponsor full name when their party has more than 1 letter i.e. `ID`. Changes `(?P<party>[DRIL])` to `(?P<party>[A-Z]+)`
3. Adds check for sourceSystem
4. Adds check for sponsors in bill_dict