### PR TITLE
fix(votes, committee_meetings):  upgrade [senate.gov, clerk.house.gov] protocol to https

### DIFF
--- a/congress/tasks/committee_meetings.py
+++ b/congress/tasks/committee_meetings.py
@@ -88,7 +88,7 @@ def fetch_senate_committee_meetings(committees, options):
     meetings = []
 
     dom = lxml.etree.fromstring(utils.download(
-        "http://www.senate.gov/general/committee_schedules/hearings.xml",
+        "https://www.senate.gov/general/committee_schedules/hearings.xml",
         "committee_schedule/senate.xml",
         options))
 

--- a/congress/tasks/utils.py
+++ b/congress/tasks/utils.py
@@ -231,7 +231,8 @@ def download(url, destination=None, options={}):
     postdata = options.get('postdata', False)
 
     timeout = float(options.get('timeout', 30))  # The low level socket api requires a float
-    urlopen_kwargs = {'timeout': timeout}
+    allowRedirects = float(options.get('allow_redirects', True)) # Follow redirects i.g. http -> https
+    urlopen_kwargs = {'timeout': timeout, 'allow_redirects': allowRedirects}
 
     # caller cares about actually bytes or only success/fail
     needs_content = options.get('needs_content', True) or not is_binary or postdata

--- a/congress/tasks/vote_info.py
+++ b/congress/tasks/vote_info.py
@@ -15,10 +15,10 @@ def fetch_vote(vote_id, options):
     vote_chamber, vote_number, vote_congress, vote_session_year = utils.split_vote_id(vote_id)
 
     if vote_chamber == "h":
-        url = "http://clerk.house.gov/evs/%s/roll%03d.xml" % (vote_session_year, int(vote_number))
+        url = "https://clerk.house.gov/evs/%s/roll%03d.xml" % (vote_session_year, int(vote_number))
     else:
         session_num = int(vote_session_year) - utils.get_congress_first_year(int(vote_congress)) + 1
-        url = "http://www.senate.gov/legislative/LIS/roll_call_votes/vote%d%d/vote_%d_%d_%05d.xml" % (int(vote_congress), session_num, int(vote_congress), session_num, int(vote_number))
+        url = "https://www.senate.gov/legislative/LIS/roll_call_votes/vote%d%d/vote_%d_%d_%05d.xml" % (int(vote_congress), session_num, int(vote_congress), session_num, int(vote_number))
 
     # fetch vote XML page
     body = utils.download(

--- a/congress/tasks/votes.py
+++ b/congress/tasks/votes.py
@@ -64,7 +64,7 @@ def run(options):
 def vote_ids_for_house(congress, session_year, options):
     vote_ids = []
 
-    index_page = "http://clerk.house.gov/evs/%s/index.asp" % session_year
+    index_page = "https://clerk.house.gov/evs/%s/index.asp" % session_year
     group_page = r"ROLL_(\d+)\.asp"
     link_pattern = r"http://clerk.house.gov/cgi-bin/vote.asp\?year=%s&rollnumber=(\d+)" % session_year
 
@@ -118,7 +118,7 @@ def vote_ids_for_senate(congress, session_year, options):
 
     vote_ids = []
 
-    url = "http://www.senate.gov/legislative/LIS/roll_call_lists/vote_menu_%s_%d.xml" % (congress, session_num)
+    url = "https://www.senate.gov/legislative/LIS/roll_call_lists/vote_menu_%s_%d.xml" % (congress, session_num)
     page = utils.download(
         url,
         "%s/votes/%s/pages/senate.xml" % (congress, session_year),


### PR DESCRIPTION
## Summary

This PR… 
- Upgrades the protocol of the URLs used to download from senate.gov and clerk.house.gov to use https. 
- Enables redirects on the request library (scraperlib)

[scraperlib's `allow_redirect` docs](https://jamesturk.github.io/scrapelib/reference/#scrapelib.Scraper.request)

Fixes: https://github.com/unitedstates/congress/issues/286