### PR TITLE
Skip tarball archiving for /test/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Skip packaging for `git archive`
+/test/ export-ignore


### PR DESCRIPTION
When the package is zipped for distribution, the tests are redundant. There may be other unnecessary files, but the tests (plus fixtures) are 2/3 of the repository's footprint. Users don't need them in the package when they do something like this:

```sh
pip install https://github.com/unitedstates/congress/archive/main.zip
```

Is this silly, when you can easily download 500MB of data? Yes, it's a little silly.