### PR TITLE
Fixing Dockerfile - Debian Jessie no longer available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@
 #  One good pattern is to write this out to the /srv/ tree, for example,
 #  /srv/pault.ag/congress/ or /srv/io.unitedstates/congress/
 
-FROM        debian:jessie
+FROM        debian:buster
 MAINTAINER  Paul R. Tagliamonte <paultag@sunlightfoundation.com>
 
 RUN apt-get update && apt-get install -y \
@@ -40,9 +40,9 @@ RUN mkdir -p /opt/theunitedstates.io/
 ADD . /opt/theunitedstates.io/congress/
 WORKDIR /opt/theunitedstates.io/congress/
 
-RUN pip install .
+RUN pip3 install .
 
-RUN echo "/opt/theunitedstates.io/congress/" > /usr/lib/python3.6/dist-packages/congress.pth
+RUN echo "/opt/theunitedstates.io/congress/" > /usr/local/lib/python3.7/dist-packages/congress.pth
 
 RUN mkdir -p /congress
 WORKDIR /congress

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,21 @@
 #  One good pattern is to write this out to the /srv/ tree, for example,
 #  /srv/pault.ag/congress/ or /srv/io.unitedstates/congress/
 
-FROM        debian:buster
-MAINTAINER  Paul R. Tagliamonte <paultag@sunlightfoundation.com>
+FROM debian:bullseye
+LABEL maintainer="Paul R. Tagliamonte <paultag@sunlightfoundation.com>"
 
 RUN apt-get update && apt-get install -y \
-    git python3-dev libxml2-dev libxslt1-dev libz-dev python3-pip wget
+    git \
+    python3 \
+    python3-dev \
+    python3-pip \
+    libxml2-dev \
+    libxslt1-dev \
+    libz-dev \
+    wget \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --upgrade pip setuptools wheel
 
 RUN mkdir -p /opt/theunitedstates.io/
 ADD . /opt/theunitedstates.io/congress/
@@ -42,10 +52,11 @@ WORKDIR /opt/theunitedstates.io/congress/
 
 RUN pip3 install .
 
-RUN echo "/opt/theunitedstates.io/congress/" > /usr/local/lib/python3.7/dist-packages/congress.pth
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN echo "/opt/theunitedstates.io/congress/" > /usr/local/lib/python3.9/dist-packages/congress.pth
 
 RUN mkdir -p /congress
 WORKDIR /congress
 
-CMD []
-ENTRYPOINT ["/opt/theunitedstates.io/congress/congress/run.py"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
This PR fixes issues with the Dockerfile for building the United States Congress scraper Docker image. The changes include:

- Updating base image to debian:buster
- Using Python 3.7 (default in Debian Buster)
- Replacing pip with pip3
- Correcting Python path for congress.pth
- Creating necessary directories

Alternatively, the PYTHONPATH environment variable can be set instead of using congress.pth.

The modified Dockerfile has been tested locally and builds successfully. Please review and merge if everything looks good.

However, certain changes have been made in order to make it work - trying to get bills via the current setup of running things does not work. I've currently made it so you can just exec in and run the usc-run necessary, but other changes may be preferred.

Thanks!