### PR TITLE
Add Rescom. in sponsor_for in bill_info

### DIFF
--- a/congress/tasks/bill_info.py
+++ b/congress/tasks/bill_info.py
@@ -392,7 +392,7 @@ def actions_for(action_list, bill_id, title):
         "prev": None,
     }
     def keep_action(item, closure):
-        if item.get('text') in (None, ""):
+        if not item.get('text'):
             return False
 
         keep = True

--- a/congress/tasks/bill_info.py
+++ b/congress/tasks/bill_info.py
@@ -234,7 +234,7 @@ def committees_for(committee_list):
             name)
 
     def get_activitiy_list(item):
-        if not item['activities']:
+        if not item.get('activities'):
             return []
         return sum([activity_text_map.get(i['name'], [i['name']]) for i in item['activities']['item']], [])
 
@@ -392,7 +392,7 @@ def actions_for(action_list, bill_id, title):
         "prev": None,
     }
     def keep_action(item, closure):
-        if item['text'] in (None, ""):
+        if item.get('text') in (None, ""):
             return False
 
         keep = True

--- a/congress/tasks/bill_info.py
+++ b/congress/tasks/bill_info.py
@@ -165,7 +165,7 @@ def sponsor_for(sponsor_dict):
         return None
 
     # TODO: Don't do regex matching here. Find another way.
-    m = re.match(r'(?P<title>(Rep\.|Sen\.|Del\.|Resident Commissioner)) (?P<name>.*?) +\[(?P<party>[DRIL])-(?P<state>[A-Z][A-Z])(-(?P<district>\d{1,2}|At Large|None))?\]$',
+    m = re.match(r'(?P<title>(Rep\.|Sen\.|Del\.|Resident Commissioner|Rescom\.)) (?P<name>.*?) +\[(?P<party>[DRIL])-(?P<state>[A-Z][A-Z])(-(?P<district>\d{1,2}|At Large|None))?\]$',
         sponsor_dict['fullName'])
 
     if not m:


### PR DESCRIPTION
## Missing Rescom. RegExp

Reference bill: `s4085-118`

Several bills in session 118 are failing to download because the `sponsor_for` logic is failing to parse the sponsor fullName.

In particular, bills sponsored by `Rescom. González-Colón, Jenniffer [R-PR-At Large]` are failing because the regex doesn't account for `Rescom.`

## Key Errors

Reference bills: `['s4085-118', 's1805-118', 's1331-118']`

Fixes a `KeyError` issue with accessing missing properties for the bills above.