### PR TITLE
bills: fix crash when 'text' missing in summary object

### DIFF
--- a/congress/tasks/bill_info.py
+++ b/congress/tasks/bill_info.py
@@ -189,12 +189,14 @@ def summary_for(summaries):
     # Take the most recent summary, by looking at the lexicographically last updateDate.
     summary = sorted(summaries, key = lambda s: s['updateDate'])[-1]
 
+    text = summary['text'] if 'text' in summary else ''
+
     # Build dict.
     return {
         "date": summary['updateDate'],
         "as": summary['actionDesc'],
         "asOf": summary['actionDate'],
-        "text": strip_tags(summary['text']),
+        "text": strip_tags(text),
     }
 
 def strip_tags(text):


### PR DESCRIPTION
sometimes summaries don't have text i guess. this fix is the simple one that doesn't check if any other summaries have text.