### PR TITLE
update vote download process to handle redirects for invalid vote number

### DIFF
--- a/congress/tasks/vote_info.py
+++ b/congress/tasks/vote_info.py
@@ -41,6 +41,12 @@ def fetch_vote(vote_id, options):
                 os.unlink(f)
         return {'saved': False, 'ok': True, 'reason': "vote was vacated"}
 
+    if b"roll-call-vote-not-available.htm" in body:
+        # Vote showed up in the xml list of votes but no roll call file has been
+        # created yet, or script was given a completely invalid vote number.
+        # In the case of very recent votes, this error should be temporary.
+        return {"saved": False, "ok": True, "reason": "roll call vote not available"}
+
     dom = etree.fromstring(body)
 
     vote = {


### PR DESCRIPTION
In #318 I discovered a kind of race condition where the main Senate XML list of votes may have been updated with a very recent roll call vote, but the actual details of that roll call hadn't yet been published. In those cases (and in any other case where an invalid vote ID is provided to the Senate XML endpoint) the response is a redirect to a generic 404 page, which throws an error in the download process and suspends all following downloads. This patch gracefully handles that specific redirect response.